### PR TITLE
Add Builder Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+**/docker
 **/node_modules
 **/dist
 .gitignore

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 COSMOCAM_APPLICATION_NAME ?= ahclemen/cosmocam
 COSMOCAM_NGINX_NAME ?= ahclemen/cosmocam-nginx
 COSMOCAM_MEDIASERVER_NAME ?= ahclemen/cosmocam-mediaserver
+BUILDER_NAME ?= ahclemen/cosmocam-builder
 
-build:
-	docker build --tag ${COSMOCAM_APPLICATION_NAME} . --file ./docker/main/Dockerfile --push
+builder:
+	docker build --tag ${BUILDER_NAME} . --file ./docker/builder/Dockerfile
+
+main:
+	docker build --tag ${COSMOCAM_APPLICATION_NAME} . --file ./docker/main/Dockerfile
 
 nginx:
-	docker build --tag ${COSMOCAM_NGINX_NAME} . --file ./docker/nginx/Dockerfile --push
+	docker build --tag ${COSMOCAM_NGINX_NAME} . --file ./docker/nginx/Dockerfile
 
 mediaserver:
-	docker build --tag ${COSMOCAM_MEDIASERVER_NAME} . --file ./docker/mediaserver/Dockerfile --push
+	docker build --tag ${COSMOCAM_MEDIASERVER_NAME} . --file ./docker/mediaserver/Dockerfile

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18
+
+# Install dependencies
+RUN \
+	set -x \
+	&& apt-get update \
+	&& apt-get install -y net-tools build-essential python3 python3-pip
+
+WORKDIR /app
+
+RUN NODE_ENV=development
+RUN npm install typescript -g
+RUN yarn global add lerna
+COPY . .
+RUN yarn

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -1,17 +1,9 @@
-FROM node:18
+FROM ahclemen/cosmocam-builder:latest
 
-# Install dependencies
-RUN \
-	set -x \
-	&& apt-get update \
-	&& apt-get install -y net-tools build-essential python3 python3-pip
-
-WORKDIR /app
-
-RUN NODE_ENV=development
-RUN npm install typescript -g
-RUN yarn global add lerna
-COPY . .
+COPY ./packages/cosmocam-backend ./packages/cosmocam-backend
+COPY ./packages/cosmocam-frontend ./packages/cosmocam-frontend
+COPY ./packages/cosmocam-mediaserver ./packages/cosmocam-mediaserver
+COPY ./packages/nginx ./packages/nginx
 RUN yarn
 RUN tsc -p ./packages/shared/tsconfig.json
 RUN tsc -p ./packages/cosmocam-backend/tsconfig.json

--- a/docker/mediaserver/Dockerfile
+++ b/docker/mediaserver/Dockerfile
@@ -1,19 +1,12 @@
-FROM node:18
+FROM ahclemen/cosmocam-builder:latest
 
-# Install dependencies
-RUN \
-	set -x \
-	&& apt-get update \
-	&& apt-get install -y net-tools build-essential python3 python3-pip
-
-WORKDIR /app
-
-RUN NODE_ENV=development
-RUN npm install typescript -g
-RUN yarn global add lerna
-COPY . .
+COPY ./packages/cosmocam-backend ./packages/cosmocam-backend
+COPY ./packages/cosmocam-frontend ./packages/cosmocam-frontend
+COPY ./packages/cosmocam-mediaserver ./packages/cosmocam-mediaserver
+COPY ./packages/nginx ./packages/nginx
 RUN yarn
 RUN tsc -p ./packages/shared/tsconfig.json
+RUN tsc -p ./packages/cosmocam-backend/tsconfig.json
 RUN tsc -p ./packages/cosmocam-backend/tsconfig.json
 RUN tsc -p ./packages/cosmocam-mediaserver/tsconfig.json
 RUN NODE_ENV=production

--- a/packages/cosmocam-mediaserver/server.ts
+++ b/packages/cosmocam-mediaserver/server.ts
@@ -13,11 +13,6 @@ dotenv.config();
 const app = express();
 const port = 3002;
 
-app.use((req: any, res: any, next: any) => {
-  console.log("received request");
-  next();
-});
-
 app.use(cors());
 app.use(express.json());
 app.use("/streamManager", streamManagerRouter);

--- a/packages/cosmocam-mediaserver/src/middlewares/tokenAuthentication.mid.ts
+++ b/packages/cosmocam-mediaserver/src/middlewares/tokenAuthentication.mid.ts
@@ -11,13 +11,10 @@ const authenticateAccessToken = async (req: any, res: any, next: any) => {
   let url = createURL(apis.AUTHENTICATE_TOKEN);
   let val = await axios.post(url, { token });
 
-  console.log("got user stuff");
-
   try {
     req.body.user = {};
     req.body.username = val.data.username;
     req.body.email = val.data.email;
-    console.log("added user to thing");
   } catch (err) {
     console.log(err);
   }


### PR DESCRIPTION
### Description of Changes
- Add `builder` dockerfile to create a base image that has all the large Cosmocam dependencies preinstalled. This reduces build times when changes are made to Cosmocam and the Mediaserver packages, when they don't require new dependencies.